### PR TITLE
Fix: Limit DB and VCP pattern evaluation to 1 year

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -58,7 +58,7 @@ PIVOT_LOOKAHEAD_DAYS = 30    # How many days to look for a pivot breakout after 
 VOLUME_BREAKOUT_FACTOR = 1.5 # Volume on breakout day must be 1.5x the 50-day average
 
 # -- Double Bottom (DB) Pattern Parameters --
-DB_LOOKBACK_PERIOD = "2y"
+DB_LOOKBACK_PERIOD = "1y"
 
 # Prior Downtrend parameters
 DB_DOWNTREND_LOOKBACK_DAYS = 120 # Look back 4 months for a prior downtrend
@@ -74,7 +74,7 @@ DB_PIVOT_PROXIMITY_FACTOR = 0.97 # Price must be within 3% of the pivot to be co
 DB_VOLUME_DROP_FACTOR = 0.8 # Average volume on 2nd trough should be less than the 1st
 
 # -- Volatility Contraction Pattern (VCP) Parameters --
-VCP_LOOKBACK_PERIOD = "2y"
+VCP_LOOKBACK_PERIOD = "1y"
 
 # Defines the expected percentage contraction for each stage.
 # e.g., 1st contraction ~25%, 2nd ~15%, 3rd ~8%

--- a/src/screener.py
+++ b/src/screener.py
@@ -87,17 +87,21 @@ def run_screening(ticker_df):
                 continue
 
             # --- Apply Chart Pattern Analysis ---
-            hist_df = ticker.history(period="2y")
-            hist_df.index = hist_df.index.tz_localize(None)
-
             pattern_checks = [
-                ("CWH", check_cup_with_handle),
-                ("DB", check_double_bottom),
-                ("VCP", check_vcp),
+                ("CWH", check_cup_with_handle, config.CWH_LOOKBACK_PERIOD),
+                ("DB", check_double_bottom, config.DB_LOOKBACK_PERIOD),
+                ("VCP", check_vcp, config.VCP_LOOKBACK_PERIOD),
             ]
 
             pattern_found = False
-            for pattern_name, check_function in pattern_checks:
+            for pattern_name, check_function, lookback_period in pattern_checks:
+                # Fetch data using the specific lookback period for the pattern
+                hist_df = ticker.history(period=lookback_period)
+                if hist_df.empty:
+                    logging.warning(f"Skipping {pattern_name} for {symbol}: No data for lookback '{lookback_period}'.")
+                    continue
+                hist_df.index = hist_df.index.tz_localize(None)
+
                 status, reason, pattern_data = check_function(hist_df.copy())
 
                 if status != "FAIL":


### PR DESCRIPTION
This commit addresses an issue where the Double Bottom (DB) and Volatility Contraction Pattern (VCP) analyses were using a hardcoded two-year data lookback period, causing them to incorrectly identify old, irrelevant patterns.

The changes include:
1.  Updating `src/config.py` to set the lookback periods for DB and VCP patterns to `1y`.
2.  Refactoring `src/screener.py` to fetch historical data for each pattern using its specific lookback period from the configuration file, rather than using a single, hardcoded period for all patterns.