### PR TITLE
feat: Set chart drawing period to 2 years

### DIFF
--- a/src/charting.py
+++ b/src/charting.py
@@ -182,7 +182,7 @@ def generate_stock_chart(stock_data, status=None, pattern_data=None):
     symbol = stock_data['ticker']
     try:
         ticker = yf.Ticker(symbol)
-        hist = ticker.history(period="1y", interval="1d")
+        hist = ticker.history(period="2y", interval="1d")
         if hist.empty:
             print(f"Error: No historical data found for {symbol}", file=sys.stderr)
             return


### PR DESCRIPTION
This commit changes the chart drawing period from 1 year to 2 years in `src/charting.py` as requested by the user.

The change was tested with the following tickers:
- 1662.T
- 2918.T
- 6622.T

The generated charts were visually verified to confirm the two-year period.