### PR TITLE
feat: Implement correct Power Play screening logic

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -86,6 +86,10 @@ VCP_TIGHTENING_MAX_DAYS = 20 # Max days for the final tight consolidation before
 # -- Power Play Setup Parameters --
 PP_LOOKBACK_PERIOD = "1y"  # Data period to fetch for analysis
 
+# 0. Explosive Uptrend (The defining characteristic of a Power Play)
+PP_UPTREND_MIN_RISE = 2.0  # Must have at least doubled (100% rise)
+PP_UPTREND_MAX_DAYS = 40   # ...within a maximum of 40 trading days (8 weeks)
+
 # 1. Trend Filter
 PP_TREND_SMA_LONG = 200
 PP_TREND_SMA_SHORT = 50

--- a/src/power_play.py
+++ b/src/power_play.py
@@ -26,6 +26,11 @@ def check_power_play(df, sp500_data=None):
     # --- Calculate all necessary indicators ---
     _calculate_indicators(df)
 
+    # --- Stage 0: Explosive Uptrend ---
+    uptrend_ok, uptrend_reason = _check_explosive_uptrend(df)
+    if not uptrend_ok:
+        return "FAIL", f"Explosive Uptrend: {uptrend_reason}", {}
+
     # --- Stage 1: Trend Filter ---
     trend_ok, trend_reason = _check_trend_filter(df, sp500_data)
     if not trend_ok:
@@ -93,6 +98,25 @@ def _calculate_indicators(df):
     # Confirmation indicators
     df['RSI'] = ta.rsi(df['Close'], length=config.PP_CONFIRM_RSI_LENGTH)
     df.ta.macd(fast=config.PP_CONFIRM_MACD_FAST, slow=config.PP_CONFIRM_MACD_SLOW, signal=config.PP_CONFIRM_MACD_SIGNAL, append=True)
+
+
+def _check_explosive_uptrend(df):
+    """
+    Checks if the stock experienced a rapid price increase (e.g., 100% in 8 weeks)
+    which is the main characteristic of a Power Play.
+    """
+    # Use a rolling window to find the minimum price over the lookback period
+    rolling_min = df['Close'].rolling(window=config.PP_UPTREND_MAX_DAYS, min_periods=config.PP_UPTREND_MAX_DAYS).min()
+
+    # Calculate the price rise factor from the rolling minimum to the current price
+    price_rise_factor = df['Close'] / rolling_min
+
+    # Check if this factor ever exceeded the minimum required rise
+    if (price_rise_factor >= config.PP_UPTREND_MIN_RISE).any():
+        return True, "Explosive uptrend detected."
+    else:
+        max_rise = price_rise_factor.max()
+        return False, f"No explosive uptrend found (max rise was {max_rise:.2f}x)."
 
 
 def _check_trend_filter(df, sp500_data):


### PR DESCRIPTION
This commit corrects the Power Play screening logic to align with Mark Minervini's definition.

The previous implementation did not check for the defining characteristic of a Power Play: an explosive prior uptrend. This change introduces a mandatory initial filter that checks for a price rise of at least 100% within 40 trading days.

This modification ensures the screener prioritizes logical accuracy over simply finding more results, directly addressing the user's confirmed requirement for a high-precision implementation.