### PR TITLE
feat: Add command-line arguments for output paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,6 +32,18 @@ def main():
         default=None,
         help="Screen only the top N stocks from the input file."
     )
+    screen_parser.add_argument(
+        '--output-file',
+        type=str,
+        default=config.RESULTS_FILE,
+        help=f"Path to the output CSV file for screening results. Defaults to {config.RESULTS_FILE}"
+    )
+    screen_parser.add_argument(
+        '--output-charts',
+        type=str,
+        default="Output",
+        help="Directory to save the output charts. Defaults to 'Output'."
+    )
 
     args = parser.parse_args()
 
@@ -63,7 +75,11 @@ def main():
             ticker_df = ticker_df.head(args.top)
 
         # Run the main screening logic
-        run_screening(ticker_df)
+        run_screening(
+            ticker_df,
+            output_file=args.output_file,
+            output_charts=args.output_charts
+        )
 
 if __name__ == "__main__":
     main()

--- a/src/charting.py
+++ b/src/charting.py
@@ -187,7 +187,7 @@ def _draw_vcp_pattern(ax, points, hist_df):
     ax.plot(vcp_dates, vcp_prices, color='blue', linestyle='--', linewidth=1, marker='o', markersize=3)
 
 
-def generate_stock_chart(stock_data, status=None, pattern_data=None):
+def generate_stock_chart(stock_data, status=None, pattern_data=None, output_dir="Output"):
     """
     Generates and saves a detailed stock chart using a manual matplotlib layout
     and mplfinance for plotting. This provides maximum control over the final output.
@@ -320,7 +320,6 @@ def generate_stock_chart(stock_data, status=None, pattern_data=None):
 
 
         # --- 6. Save Figure ---
-        output_dir = "Output"
         os.makedirs(output_dir, exist_ok=True)
         filename_status = f"_{status}" if status else ""
         filename = f"{symbol}{filename_status}.png"

--- a/src/screener.py
+++ b/src/screener.py
@@ -17,7 +17,7 @@ from src.criteria import (
 from src.patterns import check_cup_with_handle, check_double_bottom, check_vcp
 from src.power_play import check_power_play
 
-def run_screening(ticker_df):
+def run_screening(ticker_df, output_file=config.RESULTS_FILE, output_charts="Output"):
     """
     Runs the full screening process on a DataFrame of tickers.
 
@@ -133,7 +133,12 @@ def run_screening(ticker_df):
                     })
 
                     print(f"Generating chart for {symbol} ({status} / {pattern_name})...")
-                    generate_stock_chart(stock_data, f"{status}_{pattern_name}", pattern_data)
+                    generate_stock_chart(
+                        stock_data,
+                        f"{status}_{pattern_name}",
+                        pattern_data,
+                        output_dir=output_charts
+                    )
 
                     pattern_found = True
                     break # Stop after the first matching pattern
@@ -151,10 +156,10 @@ def run_screening(ticker_df):
     # --- Save Results ---
     if qualified_stocks:
         results_df = pd.DataFrame(qualified_stocks)
-        results_df.to_csv(config.RESULTS_FILE, index=False)
+        results_df.to_csv(output_file, index=False)
         print(f"\nScreening complete. Found {len(qualified_stocks)} stocks to watch or that broke out.")
-        print(f"Final list saved to {config.RESULTS_FILE}")
-        print("Charts for these stocks have been generated in the root directory.")
+        print(f"Final list saved to {output_file}")
+        print(f"Charts for these stocks have been generated in the '{output_charts}' directory.")
     else:
         print("\nScreening complete. No stocks met all the criteria.")
 


### PR DESCRIPTION
This commit introduces two new command-line arguments to the screener:

- `--output-file`: Specifies the path for the screening results CSV file.
- `--output-charts`: Specifies the directory where chart images will be saved.

The script now uses the values provided by these arguments, with the previous hardcoded paths (`screening_results.csv` and `Output/`) serving as the default values to ensure backward compatibility.

This change allows users to easily manage multiple screening runs (e.g., for different markets like US and JP) by directing the output to separate files and directories.